### PR TITLE
Update PKGBUILD 1.0.242

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ v*.zip
 joplin*.zip
 joplin*.tar.gz
 *tar.xz
+*tar.zst
 *~

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This package contains both the desktop and cli client
 ## Installing
 
 You can use an AUR wrapper like [yay](https://aur.archlinux.org/packages/yay/):
-```
+
+```sh
 yay -S joplin
 ```
 
@@ -20,11 +21,41 @@ yay -S joplin
 
 Build with makepkg
 
-```
+```sh
 makepkg -fc
 ```
 
 Check more information on the [Archwiki](https://wiki.archlinux.org/index.php/Makepkg)
+
+## Updating
+
+Update `pkgver` in [PKGBUILD](./joplin/PKGBUILD) to the latest [Joplin release](https://github.com/laurent22/joplin/releases) version.
+
+Generate new checksums using `updpkgsums` from the `pacman-contrib` package.
+
+```sh
+updpkgsums
+```
+
+Build the package from [joplin](./joplin) folder
+
+```sh
+../build.sh
+```
+
+Install the package
+
+```sh
+makepkg -i
+```
+
+Run the Joplin GUI and CLI from a terminal to test if the install worked
+
+```sh
+joplin # CLI
+:exit
+joplin-desktop # GUI
+```
 
 ## Contributing
 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-makepkg -fc
+makepkg -sfc
 
 makepkg --printsrcinfo > .SRCINFO

--- a/joplin/.SRCINFO
+++ b/joplin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = joplin
 	pkgdesc = A note taking and to-do application with synchronization capabilities
-	pkgver = 1.0.224
+	pkgver = 1.0.242
 	pkgrel = 1
 	url = https://joplinapp.org/
 	arch = x86_64
@@ -23,11 +23,11 @@ pkgbase = joplin
 	source = joplin.desktop
 	source = joplin-desktop.sh
 	source = joplin.sh
-	source = joplin-1.0.224.tar.gz::https://github.com/laurent22/joplin/archive/v1.0.224.tar.gz
+	source = joplin-1.0.242.tar.gz::https://github.com/laurent22/joplin/archive/v1.0.242.tar.gz
 	sha256sums = f915b42c3c35b22fc9bd1525953be2363319edfa2e95288f87edfb2833ec45f1
 	sha256sums = 41bfdc95a6ee285eb644d05eb3bded72a83950d4720c3c8058ddd3c605cd625d
 	sha256sums = 5245da6f5f647d49fbe044b747994c9f5a8e98b3c2cd02757dd189426a677276
-	sha256sums = 80af12d00730fe2150ce766658f417fa39f829a99048256ca7e86dba27d069ca
+	sha256sums = 5082d1fe069afef645cd130635b24d3017b85e3e321d1e392c7971a76a24001b
 
 pkgname = joplin
 

--- a/joplin/PKGBUILD
+++ b/joplin/PKGBUILD
@@ -5,7 +5,7 @@
 # https://github.com/masterkorp/joplin-pkgbuild
 
 pkgname=joplin
-pkgver=1.0.224
+pkgver=1.0.242
 pkgrel=1
 pkgdesc="A note taking and to-do application with synchronization capabilities"
 arch=('x86_64' 'i686')
@@ -20,7 +20,7 @@ source=("${pkgname}.desktop" "${pkgname}-desktop.sh" "${pkgname}.sh"
 sha256sums=('f915b42c3c35b22fc9bd1525953be2363319edfa2e95288f87edfb2833ec45f1'
             '41bfdc95a6ee285eb644d05eb3bded72a83950d4720c3c8058ddd3c605cd625d'
             '5245da6f5f647d49fbe044b747994c9f5a8e98b3c2cd02757dd189426a677276'
-            '80af12d00730fe2150ce766658f417fa39f829a99048256ca7e86dba27d069ca')
+            '5082d1fe069afef645cd130635b24d3017b85e3e321d1e392c7971a76a24001b')
 
 build() {
   # Remove husky (git hooks) from dependencies

--- a/joplin/joplin.desktop
+++ b/joplin/joplin.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.0.242
+Version=1.0.216
 Name=Joplin
 Comment=Joplin - a note taking and to-do application with synchronization capabilities for Windows, macOS, Linux, Android and iOS.
 Exec=/usr/bin/joplin-desktop

--- a/joplin/joplin.desktop
+++ b/joplin/joplin.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.0.216
+Version=1.0.242
 Name=Joplin
 Comment=Joplin - a note taking and to-do application with synchronization capabilities for Windows, macOS, Linux, Android and iOS.
 Exec=/usr/bin/joplin-desktop


### PR DESCRIPTION
- add `--syncdeps` flag to `build.sh` script
- update Joplin version and checksums
- document updating instructions in `README.md`
- add *tar.zst to `.gitignore`