### PR TITLE
Bump joplin to v2.3.5

### DIFF
--- a/joplin/.SRCINFO
+++ b/joplin/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = joplin
-	pkgver = 2.2.7
+	pkgver = 2.3.5
 	pkgrel = 1
 	url = https://joplinapp.org/
 	install = joplin.install
@@ -28,11 +28,11 @@ pkgbase = joplin
 	source = joplin.desktop
 	source = joplin-desktop.sh
 	source = joplin.sh
-	source = joplin-2.2.7.tar.gz::https://github.com/laurent22/joplin/archive/v2.2.7.tar.gz
+	source = joplin-2.3.5.tar.gz::https://github.com/laurent22/joplin/archive/v2.3.5.tar.gz
 	sha256sums = c7c5d8b0ff9edb810ed901ea21352c9830bfa286f3c18b1292deca5b2f8febd2
 	sha256sums = a450284fe66d89aa463d129ce8fff3a0a1a783a64209e4227ee47449d5737be8
 	sha256sums = dc1236767ee055ea1d61f10e5266a23e70f3e611b405fe713ed24ca18ee9eeb5
-	sha256sums = 7883e4e2ce5c6c5ce174d890985d31ee8e3645e4834810aeba8ee049b39b7977
+	sha256sums = 8d2b819940d0f22ac5dfda256508ef17b2e662a66cd31d25596af15d6cf59103
 
 pkgname = joplin
 	pkgdesc = A note taking and to-do application with synchronization capabilities - CLI App

--- a/joplin/PKGBUILD
+++ b/joplin/PKGBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Alfredo Palhares <alfredo at palhares dot me>
 # Contributor: Mark Wagie <mark dot wagie at tutanota dot com>
 # Contributor:  Matteo Parolari
+# Contributor: gardar <aur@gardar.net>
 
 # Please contribute to:
 # https://github.com/alfredopalhares/arch-pkgbuilds
 
 pkgbase="joplin"
 pkgname=('joplin' 'joplin-desktop')
-pkgver=2.2.7
+pkgver=2.3.5
 groups=('joplin')
 pkgrel=1
 install="joplin.install"
@@ -23,7 +24,7 @@ source=("joplin.desktop" "joplin-desktop.sh" "joplin.sh"
 sha256sums=('c7c5d8b0ff9edb810ed901ea21352c9830bfa286f3c18b1292deca5b2f8febd2'
             'a450284fe66d89aa463d129ce8fff3a0a1a783a64209e4227ee47449d5737be8'
             'dc1236767ee055ea1d61f10e5266a23e70f3e611b405fe713ed24ca18ee9eeb5'
-            '7883e4e2ce5c6c5ce174d890985d31ee8e3645e4834810aeba8ee049b39b7977')
+            '8d2b819940d0f22ac5dfda256508ef17b2e662a66cd31d25596af15d6cf59103')
 
 
 # local npm cache directory


### PR DESCRIPTION
Current version (2.2.7) is sync incompatible with the latest version of the android app, hope you can merge this soon!