### PR TITLE
gof5: Remove unused optdepends

### DIFF
--- a/gof5/.SRCINFO
+++ b/gof5/.SRCINFO
@@ -1,13 +1,12 @@
 pkgbase = gof5
 	pkgdesc = Open Source F5 VPN client
 	pkgver = 0.1.4
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/kayrus/gof5
 	arch = x86_64
 	license = Apache
 	makedepends = go
 	depends = base
-	optdepends = 
 	source = gof5-0.1.4.tar.gz::https://github.com/kayrus/gof5/archive/v0.1.4.tar.gz
 	sha256sums = 2a0e8695660b04c7d0def347978e33360be9d54fbcdf26c2cf9e5f4eb83a7d98
 

--- a/gof5/PKGBUILD
+++ b/gof5/PKGBUILD
@@ -5,12 +5,11 @@
 
 pkgname=gof5
 pkgver=0.1.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Open Source F5 VPN client"
 arch=('x86_64')
 depends=('base')
 makedepends=('go')
-optdepends=('')
 url="https://github.com/kayrus/gof5"
 license=('Apache')
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/kayrus/gof5/archive/v${pkgver}.tar.gz")


### PR DESCRIPTION
Hello!

paru (AUR helper) fails to parse .SRCINFO:

```
$ paru -S gof5
:: Resolving dependencies...
:: Calculating conflicts...
:: Calculating inner conflicts...

Aur (1) gof5-0.1.4-1

:: Proceed to review? [Y/n]: y

:: Downloading PKGBUILDs...
 (1/1) gof5-0.1.4-1                                 [-----------------------------------------------------]
error: failed to parse srcinfo for 'gof5-0.1.4-1': key 'optdepends' requires a value: Line 10: optdepends =
```

This commit removes fix this removing `optdepends` from PKGBUILD and .SRCINFO.

Thank you for packaging gof5. Regards!