### PR TITLE
Joplin Desktop: Support arm64 and Asahi Linux

### DIFF
--- a/joplin/.SRCINFO
+++ b/joplin/.SRCINFO
@@ -5,6 +5,7 @@ pkgbase = joplin
 	install = joplin.install
 	arch = x86_64
 	arch = i686
+	arch = aarch64
 	groups = joplin
 	license = MIT
 	makedepends = git

--- a/joplin/PKGBUILD
+++ b/joplin/PKGBUILD
@@ -15,7 +15,7 @@ install="joplin.install"
 depends=('electron' 'gtk3' 'libexif' 'libgsf' 'libjpeg-turbo' 'libwebp' 'libxss' 'nodejs>=17.3'
          'nss' 'orc' 'rsync' 'libvips')
 optdepends=('libappindicator-gtk3: for tray icon')
-arch=('x86_64' 'i686')
+arch=('x86_64' 'i686' 'aarch64')
 makedepends=('git' 'npm' 'yarn' 'python2' 'rsync' 'jq' 'yq' 'electron' 'libgsf' 'node-gyp>=8.4.1' 'libvips')
 url="https://joplinapp.org/"
 license=('MIT')
@@ -84,6 +84,9 @@ build() {
   # Force Lang
   # INFO: https://github.com/alfredopalhares/joplin-pkgbuild/issues/25
   export LANG=en_US.utf8
+
+  # Until it is fixed upstream, manually override the electron version
+  $yarn_bin workspace @joplin/app-desktop add electron@19.0.10
 
   msg2 "Installing dependencies through Yarn 3..."
   # FSevents is on the optinal dependencies and its Mac Only
@@ -180,7 +183,7 @@ package_joplin-desktop() {
 
   msg2 "Packaging the desktop..."
   # TODO: Cleanup app.asar file
-  cd dist/linux-unpacked/
+  cd dist/linux-*unpacked/
   mkdir -p "${pkgdir}/usr/share/joplin-desktop"
   cp -R "." "${pkgdir}/usr/share/joplin-desktop"
   msg2 "Installing LICENSE..."


### PR DESCRIPTION
Only small changes are needed to support ARM64, including Asahi Linux
- Add aarch64 to supported arches
- Add an * to the `dist` directory because the directory is `dist/linux-arm64-unpacked` when built on an arm64 machine
- Upgrade Electron to 19.0.10. This change is needed for Asahi Linux due to the kernel [only supporting 16k page sizes](https://asahilinux.org/2022/03/asahi-linux-alpha-release/). Electron < 19.0.0 just crashes on start up in Asahi Linux. Since this change is not needed for all ARM64 devices I'm happy to move it to a different PR if you'd like. Here is the [upstream PR](https://github.com/laurent22/joplin/pull/6888) to upgrade Electron in Joplin desktop.