### PR TITLE
Upgrade to v3.0.13

### DIFF
--- a/joplin/.SRCINFO
+++ b/joplin/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = joplin
-	pkgver = 2.14.20
+	pkgver = 3.0.13
 	pkgrel = 1
 	url = https://joplinapp.org/
 	install = joplin.install
@@ -16,7 +16,8 @@ pkgbase = joplin
 	makedepends = yq
 	makedepends = electron
 	makedepends = libgsf
-	makedepends = node-gyp>=8.4.1
+	makedepends = node-gyp>=9.4.1
+	makedepends = python-setuptools
 	depends = electron
 	depends = gtk3
 	depends = libexif
@@ -24,7 +25,7 @@ pkgbase = joplin
 	depends = libjpeg-turbo
 	depends = libwebp
 	depends = libxss
-	depends = nodejs>=17.3
+	depends = nodejs>=20.15.0
 	depends = nss
 	depends = orc
 	depends = rsync
@@ -32,11 +33,11 @@ pkgbase = joplin
 	source = joplin.desktop
 	source = joplin-desktop.sh
 	source = joplin.sh
-	source = joplin-2.14.20.tar.gz::https://github.com/laurent22/joplin/archive/v2.14.20.tar.gz
+	source = joplin-3.0.13.tar.gz::https://github.com/laurent22/joplin/archive/v3.0.13.tar.gz
 	sha256sums = c7c5d8b0ff9edb810ed901ea21352c9830bfa286f3c18b1292deca5b2f8febd2
 	sha256sums = a450284fe66d89aa463d129ce8fff3a0a1a783a64209e4227ee47449d5737be8
 	sha256sums = b6a8361cbc59e7dbc33bcc427274efb945d8d654bf013b12c7021be681f568e2
-	sha256sums = 919e9300e66bc6c24a282cbf93c43c228cdfe3227bdb1eaa50fdadef4734901b
+	sha256sums = 2bf91efec385801bb13b62b459e21c1eb80d35a772f517ba7d079eb91faa1f98
 
 pkgname = joplin
 	pkgdesc = A note taking and to-do application with synchronization capabilities - CLI App

--- a/joplin/.SRCINFO
+++ b/joplin/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = joplin
-	pkgver = 2.12.15
+	pkgver = 2.14.19
 	pkgrel = 1
 	url = https://joplinapp.org/
 	install = joplin.install

--- a/joplin/.SRCINFO
+++ b/joplin/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = joplin
-	pkgver = 2.14.19
+	pkgver = 2.14.20
 	pkgrel = 1
 	url = https://joplinapp.org/
 	install = joplin.install

--- a/joplin/.SRCINFO
+++ b/joplin/.SRCINFO
@@ -17,7 +17,6 @@ pkgbase = joplin
 	makedepends = electron
 	makedepends = libgsf
 	makedepends = node-gyp>=8.4.1
-	makedepends = libvips
 	depends = electron
 	depends = gtk3
 	depends = libexif
@@ -29,7 +28,6 @@ pkgbase = joplin
 	depends = nss
 	depends = orc
 	depends = rsync
-	depends = libvips
 	optdepends = libappindicator-gtk3: for tray icon
 	source = joplin.desktop
 	source = joplin-desktop.sh
@@ -46,7 +44,6 @@ pkgname = joplin
 	depends = libsecret
 	depends = nodejs
 	depends = python
-	depends = libvips
 
 pkgname = joplin-desktop
 	pkgdesc = A note taking and to-do application with synchronization capabilities - Desktop

--- a/joplin/PKGBUILD
+++ b/joplin/PKGBUILD
@@ -79,7 +79,7 @@ build() {
     # INFO: https://github.com/alfredopalhares/joplin-pkgbuild/issues/25
     export LANG=en_US.utf8
 
-    #msg2 "Installing dependencies through Yarn 3..."
+    msg2 "Installing dependencies through Yarn 3..."
     eval $yarn_bin
 
     msg2 "Building the workspace"

--- a/joplin/PKGBUILD
+++ b/joplin/PKGBUILD
@@ -8,15 +8,14 @@
 
 pkgbase="joplin"
 pkgname=('joplin' 'joplin-desktop')
-pkgver=2.12.15
+pkgver=2.14.19
 groups=('joplin')
 pkgrel=1
 install="joplin.install"
-depends=('electron' 'gtk3' 'libexif' 'libgsf' 'libjpeg-turbo' 'libwebp' 'libxss' 'nodejs>=17.3'
-'nss' 'orc' 'rsync' 'libvips')
+depends=('electron' 'gtk3' 'libexif' 'libgsf' 'libjpeg-turbo' 'libwebp' 'libxss' 'nodejs>=17.3' 'nss' 'orc' 'rsync')
 optdepends=('libappindicator-gtk3: for tray icon')
 arch=('x86_64' 'i686')
-makedepends=('git' 'npm' 'yarn' 'python' 'rsync' 'jq' 'yq' 'electron' 'libgsf' 'node-gyp>=8.4.1' 'libvips')
+makedepends=('git' 'npm' 'yarn' 'python' 'rsync' 'jq' 'yq' 'electron' 'libgsf' 'node-gyp>=8.4.1')
 url="https://joplinapp.org/"
 license=('MIT')
 source=("joplin.desktop" "joplin-desktop.sh" "joplin.sh"
@@ -24,7 +23,7 @@ source=("joplin.desktop" "joplin-desktop.sh" "joplin.sh"
 sha256sums=('c7c5d8b0ff9edb810ed901ea21352c9830bfa286f3c18b1292deca5b2f8febd2'
     'a450284fe66d89aa463d129ce8fff3a0a1a783a64209e4227ee47449d5737be8'
     '16aed6c4881efcef3fd86f7c07afb4c743e24d9da342438a8167346a015629e0'
-'1ab8cac6ded11abc5a6437b58342b519466cbf869bf3e7cc0a651413ff8faa0a')
+    'ec65d5bbd790c65a0f6f4b7ed6838e13bcda5a4ec63488262a28db4b047b7050')
 
 # local npm cache directory
 _yarn_cache="yarn-cache"
@@ -49,11 +48,15 @@ _get_yarn_bin() {
 prepare() {
     local cache=$(_get_cache)
     local yarn_bin=$(_get_yarn_bin)
+    local package_json="${srcdir}/joplin-${pkgver}/package.json"
     msg2 "Yarn cache directory: $cache"
     msg2 "Yarn binary: ${yarn_bin}"
 
     msg2 "Disabling husky (git hooks)"
-    sed -i '/"husky": ".*"/d' "${srcdir}/joplin-${pkgver}/package.json"
+    # This is ugly and unreadable, but it gets rid of "husky" everwhere without breaking package.json
+    cat <<< $(jq 'with_entries( select(.key == "resolutions").value |= del(.husky) )' ${package_json}) > "${package_json}"
+    cat <<< $(jq 'del(.husky)' "${package_json}") > "${package_json}"
+    cat <<< $(jq 'with_entries( select(.key == "devDependencies").value |= del(.husky) )' "${package_json}") > "${package_json}"
 
     # There are so many people
     msg2 "Checking Node PATH"
@@ -119,7 +122,7 @@ check() {
 
 package_joplin() {
     pkgdesc="A note taking and to-do application with synchronization capabilities - CLI App"
-    depends=('coreutils' 'libsecret' 'nodejs' 'python' 'libvips')
+    depends=('coreutils' 'libsecret' 'nodejs' 'python')
 
     local cache=$(_get_cache)
     local yarn_bin=$(_get_yarn_bin)

--- a/joplin/PKGBUILD
+++ b/joplin/PKGBUILD
@@ -8,22 +8,22 @@
 
 pkgbase="joplin"
 pkgname=('joplin' 'joplin-desktop')
-pkgver=2.14.20
+pkgver=3.0.13
 groups=('joplin')
 pkgrel=1
 install="joplin.install"
-depends=('electron' 'gtk3' 'libexif' 'libgsf' 'libjpeg-turbo' 'libwebp' 'libxss' 'nodejs>=17.3' 'nss' 'orc' 'rsync')
+depends=('electron' 'gtk3' 'libexif' 'libgsf' 'libjpeg-turbo' 'libwebp' 'libxss' 'nodejs>=20.15.0' 'nss' 'orc' 'rsync')
 optdepends=('libappindicator-gtk3: for tray icon')
 arch=('x86_64' 'i686')
-makedepends=('git' 'npm' 'yarn' 'python' 'rsync' 'jq' 'yq' 'electron' 'libgsf' 'node-gyp>=8.4.1')
+makedepends=('git' 'npm' 'yarn' 'python' 'rsync' 'jq' 'yq' 'electron' 'libgsf' 'node-gyp>=9.4.1' 'python-setuptools')
 url="https://joplinapp.org/"
 license=('MIT')
 source=("joplin.desktop" "joplin-desktop.sh" "joplin.sh"
 "joplin-${pkgver}.tar.gz::https://github.com/laurent22/joplin/archive/v${pkgver}.tar.gz")
 sha256sums=('c7c5d8b0ff9edb810ed901ea21352c9830bfa286f3c18b1292deca5b2f8febd2'
-    'a450284fe66d89aa463d129ce8fff3a0a1a783a64209e4227ee47449d5737be8'
-    'b6a8361cbc59e7dbc33bcc427274efb945d8d654bf013b12c7021be681f568e2'
-'919e9300e66bc6c24a282cbf93c43c228cdfe3227bdb1eaa50fdadef4734901b')
+            'a450284fe66d89aa463d129ce8fff3a0a1a783a64209e4227ee47449d5737be8'
+            'b6a8361cbc59e7dbc33bcc427274efb945d8d654bf013b12c7021be681f568e2'
+            '2bf91efec385801bb13b62b459e21c1eb80d35a772f517ba7d079eb91faa1f98')
 
 # local npm cache directory
 _yarn_cache="yarn-cache"
@@ -54,44 +54,12 @@ prepare() {
     local cache=$(_get_cache)
     local yarn_bin=$(_get_yarn_bin)
     _set_env
-    msg2 "Yarn cache directoaary: $cache"
+    msg2 "Yarn cache directory: ${cache}"
     msg2 "Yarn binary: ${yarn_bin}"
-    $yarn_bin --version
-
-    msg2 "Disabling husky (git hooks)" 
-    # This is ugly and unreadable, but it gets rid of "husky" everwhere
-    # without breaking package.json
-    #
-    # Unfortunatly, husky installs git hooks in this (arch-pkgbuilds)
-    # repo when we run the below build script
-    cat <<< $(jq 'with_entries( select(.key == "resolutions").value |= del(.husky) )' ${package_json}) > "${package_json}"
-    cat <<< $(jq 'del(.husky)' "${package_json}") > "${package_json}"
-    cat <<< $(jq 'with_entries( select(.key == "devDependencies").value |= del(.husky) )' "${package_json}") > "${package_json}"
-
-
-    # There are so many people
-    msg2 "Checking Node PATH"
-    # local w_node=$(which node)
-    # if [[ $w_node != "/usr/bin/node" ]]; then
-    #     msg2 "WARNING: Using path ${w_node} beware its not the default path, check if you are using nvm or similar"
-    # fi
-
-    msg2 "Removing yarm version lock"
-    # jq "del(.packageManager)" "${srcdir}/joplin-${pkgver}/package.json" > "${srcdir}/joplin-${pkgver}/package_new.json"
-    # mv "${srcdir}/joplin-${pkgver}/package_new.json" "${srcdir}/joplin-${pkgver}/package.json"
-
-    msg2 "Disabling Optional Dependencias"
-    # find "${srcdir}/joplin-${pkgver}/" -type f -name "package.json" -exec sed -i 's_"optionalDependencies":_"UNUSED":_' {} \;
-
-    msg2 "Tweaking .yarnrc"
-    # yq -i -y ".cacheFolder=(\"${cache}\")" "${srcdir}/joplin-${pkgver}/.yarnrc.yml"
-
-    msg2 "Tweaking lerna.json"
-    # local tmp_json="$(mktemp --tmpdir="$srcdir")"
-    # local lerna_json="${srcdir}/joplin-${pkgver}/lerna.json"
+    ${yarn_bin} --version
 
     msg2 "Deleting Unnecessary Packages"
-    rm -r "${srcdir}/joplin-${pkgver}/packages/app-mobile"
+#?    rm -r "${srcdir}/joplin-${pkgver}/packages/app-mobile"
     rm -r "${srcdir}/joplin-${pkgver}/packages/app-clipper"
     rm -r "${srcdir}/joplin-${pkgver}/packages/server"
 }
@@ -103,23 +71,24 @@ build() {
     _set_env
 
     msg2 "Yarn binary: ${yarn_bin}"
-    msg2 "Yarn cache directory: $cache"
+    msg2 "Yarn cache directory: ${cache}"
     cd "${srcdir}/joplin-${pkgver}"
 
     # Force Lang
     # INFO: https://github.com/alfredopalhares/joplin-pkgbuild/issues/25
     export LANG=en_US.utf8
 
-    msg2 "Installing dependencies through Yarn 3..."
+    #msg2 "Installing dependencies through Yarn 3..."
+    # not sure why this isn't working or why we need to do this...
     eval $yarn_bin
 
     msg2 "Building the workspace"
-    $yarn_bin install
-    echo "hello"
-    $yarn_bin workspace @joplin/lib install
-    $yarn_bin workspace @joplin/renderer install
-    $yarn_bin workspace @joplin/app-desktop install
-    $yarn_bin workspace @joplin/app-desktop run electron-builder build --linux
+    # added --inline-builds to dump logs to screen when building
+    ${yarn_bin} install --inline-builds
+    ${yarn_bin} workspace @joplin/lib install --inline-builds
+    ${yarn_bin} workspace @joplin/renderer install --inline-builds
+    ${yarn_bin} workspace @joplin/app-desktop install --inline-builds
+    ${yarn_bin} workspace @joplin/app-desktop run electron-builder build --linux
 }
 
 #FIXME: These checks fail on some machines, even with the exit 0
@@ -137,22 +106,22 @@ package_joplin() {
     local cache=$(_get_cache)
     local yarn_bin=$(_get_yarn_bin)
     _set_env
-    msg2 "Yarn cache directory: $cache"
+    msg2 "Yarn cache directory: ${cache}"
 
     msg2 "Packaging CLI with Repo Gulp"
     cd "${srcdir}/joplin-${pkgver}/packages/app-cli/"
     # npx gulp build
-    gulp_bin=$($yarn_bin bin gulp)
+    gulp_bin=$(${yarn_bin} bin gulp)
     msg2 "Using gulp: ${gulp_bin}"
     ${gulp_bin} build
-    $yarn_bin pack
+    ${yarn_bin} pack
 
     msg2 "Installing package"
     export SKIP_YARN_COREPACK_CHECK=0
     mkdir -p "${pkgdir}/usr/share/joplin/"
     mv package.tgz "${pkgdir}/usr/share/joplin/"
     cd "${pkgdir}/usr/share/joplin/"
-    yes | $yarn_bin init
+    yes | ${yarn_bin} init
     # FIXME: The repo the actually install does not work
     # You also need to pipe yes, for depeendy
     # $yarn_bin add ./package.tgz
@@ -164,7 +133,7 @@ package_joplin() {
     find "${pkgdir}/usr" -type d -exec chmod 755 {} +
 
     msg2 "Removing References to \$pkgdir"
-    find "$pkgdir" -name package.json -print0 | xargs -0 sed -i "/_where/d"
+    find "${pkgdir}" -name package.json -print0 | xargs -0 sed -i "/_where/d"
 
     msg2 "Fixing Permissions set by npm"
     # npm gives ownership of ALL FILES to build user

--- a/joplin/PKGBUILD
+++ b/joplin/PKGBUILD
@@ -8,7 +8,7 @@
 
 pkgbase="joplin"
 pkgname=('joplin' 'joplin-desktop')
-pkgver=2.14.19
+pkgver=2.14.20
 groups=('joplin')
 pkgrel=1
 install="joplin.install"
@@ -23,7 +23,7 @@ source=("joplin.desktop" "joplin-desktop.sh" "joplin.sh"
 sha256sums=('c7c5d8b0ff9edb810ed901ea21352c9830bfa286f3c18b1292deca5b2f8febd2'
     'a450284fe66d89aa463d129ce8fff3a0a1a783a64209e4227ee47449d5737be8'
     '16aed6c4881efcef3fd86f7c07afb4c743e24d9da342438a8167346a015629e0'
-    'ec65d5bbd790c65a0f6f4b7ed6838e13bcda5a4ec63488262a28db4b047b7050')
+    '919e9300e66bc6c24a282cbf93c43c228cdfe3227bdb1eaa50fdadef4734901b')
 
 # local npm cache directory
 _yarn_cache="yarn-cache"
@@ -53,7 +53,11 @@ prepare() {
     msg2 "Yarn binary: ${yarn_bin}"
 
     msg2 "Disabling husky (git hooks)"
-    # This is ugly and unreadable, but it gets rid of "husky" everwhere without breaking package.json
+    # This is ugly and unreadable, but it gets rid of "husky" everwhere
+    # without breaking package.json
+    #
+    # Unfortunatly, husky installs git hooks in this (arch-pkgbuilds)
+    # repo when we run the below build script
     cat <<< $(jq 'with_entries( select(.key == "resolutions").value |= del(.husky) )' ${package_json}) > "${package_json}"
     cat <<< $(jq 'del(.husky)' "${package_json}") > "${package_json}"
     cat <<< $(jq 'with_entries( select(.key == "devDependencies").value |= del(.husky) )' "${package_json}") > "${package_json}"
@@ -142,7 +146,7 @@ package_joplin() {
     $yarn_bin init
     # FIXME: The repo wran crashed
     # You also need to pipe yes, for depeendy
-    yes | yarn add ./package.tgz
+    yes | $yarn_bin add ./package.tgz
 
     msg2 "Fixing Directories Permissions"
     # Non-deterministic race in npm gives 777 permissions to random directories.

--- a/joplin/PKGBUILD
+++ b/joplin/PKGBUILD
@@ -59,7 +59,8 @@ prepare() {
     ${yarn_bin} --version
 
     msg2 "Deleting Unnecessary Packages"
-#?    rm -r "${srcdir}/joplin-${pkgver}/packages/app-mobile"
+# Joplin build script, tests for files inside this directory
+#    rm -r "${srcdir}/joplin-${pkgver}/packages/app-mobile"
     rm -r "${srcdir}/joplin-${pkgver}/packages/app-clipper"
     rm -r "${srcdir}/joplin-${pkgver}/packages/server"
 }
@@ -79,11 +80,10 @@ build() {
     export LANG=en_US.utf8
 
     #msg2 "Installing dependencies through Yarn 3..."
-    # not sure why this isn't working or why we need to do this...
     eval $yarn_bin
 
     msg2 "Building the workspace"
-    # added --inline-builds to dump logs to screen when building
+# added --inline-builds to dump logs to screen when building
     ${yarn_bin} install --inline-builds
     ${yarn_bin} workspace @joplin/lib install --inline-builds
     ${yarn_bin} workspace @joplin/renderer install --inline-builds


### PR DESCRIPTION
* Removes `libvips` -- didn't need it to build this version.
* Updated `PKGBUILD` bash variable references to always use `${}` syntax.

Tested using `makechrootpkg`:

```
(ins)sahal@shakuntala[~/code/arch-pkgbuilds/joplin]$ cat mount/makepkg.sh
#!/usr/bin/env bash

export CHROOT=/mnt/large/cache/chroot
mkdir -p $CHROOT
mkarchroot $CHROOT/root base-devel

arch-nspawn $CHROOT/root pacman -Syu --noconfirm \
      electron \
      git \
      gtk3 \
      jq \
      libexif \
      libgsf \
      libjpeg-turbo \
      libwebp \
      libxss \
      node-gyp \
      nodejs \
      npm \
      nss \
      orc \
      python \
      rsync \
      yarn \
      yq \
      python-setuptools

makechrootpkg -c -r $CHROOT

```
build log: [buildlog.txt](https://github.com/user-attachments/files/16138583/buildlog.txt)